### PR TITLE
fix(log): 优化文案，调整缩进

### DIFF
--- a/docs/zh/mini-program/index.md
+++ b/docs/zh/mini-program/index.md
@@ -11,9 +11,9 @@ MiniProgramApp, err := miniProgram.NewMiniProgram(&miniProgram.UserConfig{
   HttpDebug: true,
   Log: miniProgram.Log{
     Level: "debug",
-    // 可以重定向到你的目录下，如果设置File和Error，默认会在当前目录下的wechat文件夹下生成日志
-    File:  "/Users/user/wechat/mini-program/info.log", 
-	  Error: "/Users/user/wechat/mini-program/error.log",
+    // 可以重定向到你的目录下，如果未设置File和Error，默认会在当前目录下的wechat文件夹下生成日志
+    File:  "/Users/user/wechat/mini-program/info.log",
+    Error: "/Users/user/wechat/mini-program/error.log",
     Stdout: false, //  是否打印在终端
   },
   // 可选，不传默认走程序内存

--- a/docs/zh/official-account/index.md
+++ b/docs/zh/official-account/index.md
@@ -17,9 +17,9 @@ OfficialAccountApp, err := officialAccount.NewOfficialAccount(&officialAccount.U
 
   Log: officialAccount.Log{
     Level: "debug",
-    // 可以重定向到你的目录下，如果设置File和Error，默认会在当前目录下的wechat文件夹下生成日志
+    // 可以重定向到你的目录下，如果未设置File和Error，默认会在当前目录下的wechat文件夹下生成日志
     File:  "/Users/user/wechat/official-account/info.log", 
-	  Error: "/Users/user/wechat/official-account/error.log",
+    Error: "/Users/user/wechat/official-account/error.log",
     Stdout: false, //  是否打印在终端
   },
 

--- a/docs/zh/official-account/server.md
+++ b/docs/zh/official-account/server.md
@@ -26,7 +26,7 @@ OfficialAccountApp, err := officialAccount.NewOfficialAccount(&officialAccount.U
 	// ResponseType: os.Getenv("response_type"),
 	Log: officialAccount.Log{
 		Level: "debug",
-		// 可以重定向到你的目录下，如果设置File和Error，默认会在当前目录下的wechat文件夹下生成日志
+		// 可以重定向到你的目录下，如果未设置File和Error，默认会在当前目录下的wechat文件夹下生成日志
     	File:  "/Users/user/wechat/official-account/info.log", 
 	    Error: "/Users/user/wechat/official-account/error.log",
 		Stdout: false, //  是否打印在终端

--- a/docs/zh/open-platform/authFlow.md
+++ b/docs/zh/open-platform/authFlow.md
@@ -17,7 +17,7 @@ OpenPlatformApp, err := openPlatform.NewOpenPlatform(&openPlatform.UserConfig{
 
   Log: openPlatform.Log{
     Level: "debug",
-    // 可以重定向到你的目录下，如果设置File和Error，默认会在当前目录下的wechat文件夹下生成日志
+    // 可以重定向到你的目录下，如果未设置File和Error，默认会在当前目录下的wechat文件夹下生成日志
     File:  "/Users/user/wechat/platform/info.log", 
     Error: "/Users/user/wechat/platform/error.log",
   }, // 日志输出位置

--- a/docs/zh/payment/index.md
+++ b/docs/zh/payment/index.md
@@ -30,9 +30,9 @@ PaymentService, err := payment.NewPayment(&payment.UserConfig{
   HttpDebug:          true,
   Log: payment.Log{
     Level: "debug",
-    // 可以重定向到你的目录下，如果设置File和Error，默认会在当前目录下的wechat文件夹下生成日志
+    // 可以重定向到你的目录下，如果未设置File和Error，默认会在当前目录下的wechat文件夹下生成日志
     File:  "/Users/user/wechat/payment/info.log", 
-	  Error: "/Users/user/wechat/payment/error.log",
+    Error: "/Users/user/wechat/payment/error.log",
     Stdout: false, //  是否打印在终端
   },
   Http: payment.Http{

--- a/docs/zh/start/common.md
+++ b/docs/zh/start/common.md
@@ -132,7 +132,7 @@ PowerWeChat提供了日志模块，默认情况下，日志会输出到控制台
 
 Log: work.Log{
 		    Level: "debug",
-			// 可以重定向到你的目录下，如果设置File和Error，默认会在当前目录下的wechat文件夹下生成日志
+			// 可以重定向到你的目录下，如果未设置File和Error，默认会在当前目录下的wechat文件夹下生成日志
 			File:  "/Users/user/wechat/work/info.log", 
 			Error: "/Users/user/wechat/work/error.log",
 			Stdout: false, //  是否打印在终端
@@ -159,7 +159,7 @@ import (
 Log: miniProgram.Log{
 			Driver: &drivers.SimpleLogger{},
 			Level:  "debug",
-			// 可以重定向到你的目录下，如果设置File和Error，默认会在当前目录下的wechat文件夹下生成日志
+			// 可以重定向到你的目录下，如果未设置File和Error，默认会在当前目录下的wechat文件夹下生成日志
 		  	File:  "/Users/user/wechat/mini-program/info.log", 
 		  	Error: "/Users/user/wechat/mini-program/error.log",
 			Stdout: false, //  是否打印在终端

--- a/docs/zh/start/quick-start.md
+++ b/docs/zh/start/quick-start.md
@@ -33,7 +33,7 @@ func main() {
     },
     Log: work.Log{
         Level:  "debug",
-        // 可以重定向到你的目录下，如果设置File和Error，默认会在当前目录下的wechat文件夹下生成日志
+        // 可以重定向到你的目录下，如果未设置File和Error，默认会在当前目录下的wechat文件夹下生成日志
         File:  "/Users/user/wechat/info.log", 
         Error: "/Users/user/wechat/error.log",
         Stdout: false, //  是否打印在终端

--- a/docs/zh/wecom/index.md
+++ b/docs/zh/wecom/index.md
@@ -19,9 +19,9 @@ WeComApp, err := work.NewWork(&work.UserConfig{
   },
   Log: work.Log{
     Level:  "debug",
-    // 可以重定向到你的目录下，如果设置File和Error，默认会在当前目录下的wechat文件夹下生成日志
+    // 可以重定向到你的目录下，如果未设置File和Error，默认会在当前目录下的wechat文件夹下生成日志
     File:  "/Users/user/wechat/work/info.log", 
-	  Error: "/Users/user/wechat/work/error.log",
+    Error: "/Users/user/wechat/work/error.log",
     Stdout: false, //  是否打印在终端
   },
   HttpDebug: true,


### PR DESCRIPTION
右边修改前，左边修改后，修复了 `log` 部分空格和tab混用导致的错误

![image](https://github.com/user-attachments/assets/3a12eca4-d89d-469f-a6bf-ea1b1fd94c52)
